### PR TITLE
Add global game toolbar

### DIFF
--- a/Jazer.Game.Tests/Visual/Navigation/TestSceneToolbarMode.cs
+++ b/Jazer.Game.Tests/Visual/Navigation/TestSceneToolbarMode.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+using Jazer.Game.Overlays;
+using Jazer.Game.Screens;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Testing;
+using osu.Framework.Utils;
+
+namespace Jazer.Game.Tests.Visual.Navigation;
+
+public partial class TestSceneToolbarMode : JazerTestScene
+{
+    private JazerGame game = null!;
+
+    private JazerScreenStack screenStack => game.ChildrenOfType<JazerScreenStack>().First();
+    private Toolbar toolbar => game.ChildrenOfType<Toolbar>().First();
+
+    [BackgroundDependencyLoader]
+    private void load()
+    {
+        AddGame(game = new JazerGame());
+    }
+
+    [SetUpSteps]
+    public void Setup()
+    {
+        AddStep("exit all screens", () =>
+        {
+            while (screenStack.CurrentScreen != null)
+                screenStack.Exit();
+        });
+    }
+
+    [Test]
+    public void TestToolbarMode()
+    {
+        AddStep("add screen with toolbar", () => screenStack.Push(new TestScreen(ToolbarMode.Show)));
+        AddUntilStep("toolbar finished transform", () => !toolbar.Transforms.Any());
+        AddAssert("toolbar is visible", () => Precision.AlmostEquals(toolbar.Height, Toolbar.HEIGHT));
+        AddStep("add screen without toolbar", () => screenStack.Push(new TestScreen(ToolbarMode.Hide)));
+        AddUntilStep("toolbar finished transform", () => !toolbar.Transforms.Any());
+        AddAssert("toolbar is hidden", () => Precision.AlmostEquals(toolbar.Height, 0));
+    }
+
+    private partial class TestScreen(ToolbarMode toolbarMode) : JazerScreen
+    {
+        public override ToolbarMode ToolbarMode => toolbarMode;
+    }
+}

--- a/Jazer.Game/Configuration/JazerConfigManager.cs
+++ b/Jazer.Game/Configuration/JazerConfigManager.cs
@@ -12,6 +12,7 @@ public class JazerConfigManager(Storage storage)
         SetDefault(JazerSetting.Username, string.Empty);
         SetDefault(JazerSetting.SavePassword, false);
         SetDefault(JazerSetting.SaveUsername, true);
+        SetDefault(JazerSetting.ShowToolbar, true);
     }
 }
 
@@ -20,5 +21,6 @@ public enum JazerSetting
     AuthToken,
     Username,
     SavePassword,
-    SaveUsername
+    SaveUsername,
+    ShowToolbar,
 }

--- a/Jazer.Game/GlobalActionContainer.cs
+++ b/Jazer.Game/GlobalActionContainer.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using osu.Framework.Input.Bindings;
+
+namespace Jazer.Game;
+
+public partial class GlobalActionContainer : KeyBindingContainer<GlobalAction>
+{
+    public override IEnumerable<IKeyBinding> DefaultKeyBindings =>
+    [
+        new KeyBinding(new[] { InputKey.Control, InputKey.T }, GlobalAction.ToggleToolbar),
+    ];
+}
+
+public enum GlobalAction
+{
+    ToggleToolbar,
+}

--- a/Jazer.Game/Graphics/Containers/BorderLayout.cs
+++ b/Jazer.Game/Graphics/Containers/BorderLayout.cs
@@ -97,8 +97,8 @@ public partial class BorderLayout : CompositeDrawable
     {
         var padding = new MarginPadding
         {
-            Top = top.DrawHeight,
-            Bottom = bottom.DrawHeight,
+            Top = top.LayoutSize.Y,
+            Bottom = bottom.LayoutSize.Y,
         };
 
         right.Padding = padding;
@@ -106,8 +106,8 @@ public partial class BorderLayout : CompositeDrawable
 
         center.Padding = padding with
         {
-            Left = right.DrawWidth,
-            Right = left.DrawWidth,
+            Left = right.LayoutSize.X,
+            Right = left.LayoutSize.X,
         };
     }
 }

--- a/Jazer.Game/Graphics/Containers/BorderLayout.cs
+++ b/Jazer.Game/Graphics/Containers/BorderLayout.cs
@@ -1,5 +1,6 @@
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Layout;
 
 namespace Jazer.Game.Graphics.Containers;
 
@@ -63,6 +64,8 @@ public partial class BorderLayout : CompositeDrawable
         set => center.Child = value;
     }
 
+    private readonly LayoutValue layoutBacking = new LayoutValue(Invalidation.DrawSize, InvalidationSource.Child);
+
     public BorderLayout()
     {
         RelativeSizeAxes = Axes.Both;
@@ -75,13 +78,19 @@ public partial class BorderLayout : CompositeDrawable
             bottom,
             top,
         ];
+
+        AddLayout(layoutBacking);
     }
 
     protected override void Update()
     {
         base.Update();
 
-        updateLayout();
+        if (!layoutBacking.IsValid)
+        {
+            updateLayout();
+            layoutBacking.Validate();
+        }
     }
 
     private void updateLayout()

--- a/Jazer.Game/Graphics/Containers/BorderLayout.cs
+++ b/Jazer.Game/Graphics/Containers/BorderLayout.cs
@@ -1,0 +1,104 @@
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+
+namespace Jazer.Game.Graphics.Containers;
+
+public partial class BorderLayout : CompositeDrawable
+{
+    private readonly Container top = new Container
+    {
+        RelativeSizeAxes = Axes.X,
+        AutoSizeAxes = Axes.Y,
+    };
+
+    private readonly Container bottom = new Container
+    {
+        RelativeSizeAxes = Axes.X,
+        AutoSizeAxes = Axes.Y,
+        Anchor = Anchor.BottomLeft,
+        Origin = Anchor.BottomLeft,
+    };
+
+    private readonly Container left = new Container
+    {
+        RelativeSizeAxes = Axes.Y,
+        AutoSizeAxes = Axes.X,
+        Anchor = Anchor.TopRight,
+        Origin = Anchor.TopRight,
+    };
+
+    private readonly Container right = new Container
+    {
+        RelativeSizeAxes = Axes.Y,
+        AutoSizeAxes = Axes.X,
+    };
+
+    private readonly Container center = new Container
+    {
+        RelativeSizeAxes = Axes.Both,
+    };
+
+    public Drawable Top
+    {
+        set => top.Child = value;
+    }
+
+    public Drawable Bottom
+    {
+        set => bottom.Child = value;
+    }
+
+    public Drawable Left
+    {
+        set => right.Child = value;
+    }
+
+    public Drawable Right
+    {
+        set => left.Child = value;
+    }
+
+    public Drawable Center
+    {
+        set => center.Child = value;
+    }
+
+    public BorderLayout()
+    {
+        RelativeSizeAxes = Axes.Both;
+
+        InternalChildren =
+        [
+            center,
+            right,
+            left,
+            bottom,
+            top,
+        ];
+    }
+
+    protected override void Update()
+    {
+        base.Update();
+
+        updateLayout();
+    }
+
+    private void updateLayout()
+    {
+        var padding = new MarginPadding
+        {
+            Top = top.DrawHeight,
+            Bottom = bottom.DrawHeight,
+        };
+
+        right.Padding = padding;
+        left.Padding = padding;
+
+        center.Padding = padding with
+        {
+            Left = right.DrawWidth,
+            Right = left.DrawWidth,
+        };
+    }
+}

--- a/Jazer.Game/Graphics/JazerColour.cs
+++ b/Jazer.Game/Graphics/JazerColour.cs
@@ -1,0 +1,19 @@
+using System;
+using osuTK.Graphics;
+
+namespace Jazer.Game.Graphics;
+
+public class JazerColour
+{
+    public static Color4 Gray(float brightness) => new Color4(brightness, brightness, MathF.Pow(brightness, 0.92f), 1f);
+
+    public static Color4 Gray100 => Gray(0.9f);
+    public static Color4 Gray200 => Gray(0.7f);
+    public static Color4 Gray300 => Gray(0.5f);
+    public static Color4 Gray400 => Gray(0.35f);
+    public static Color4 Gray500 => Gray(0.22f);
+    public static Color4 Gray600 => Gray(0.15f);
+    public static Color4 Gray700 => Gray(0.1f);
+    public static Color4 Gray800 => Gray(0.05f);
+    public static Color4 Gray900 => Gray(0.025f);
+}

--- a/Jazer.Game/JazerGame.cs
+++ b/Jazer.Game/JazerGame.cs
@@ -1,6 +1,29 @@
-﻿namespace Jazer.Game
+﻿using Jazer.Game.Graphics.Containers;
+using Jazer.Game.Overlays;
+using Jazer.Game.Screens;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+
+namespace Jazer.Game
 {
     public partial class JazerGame : JazerGameBase
     {
+        private JazerScreenStack screenStack = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Toolbar toolbar;
+
+            Add(new BorderLayout
+            {
+                RelativeSizeAxes = Axes.Both,
+                Top = toolbar = new Toolbar(),
+                Center = screenStack = new JazerScreenStack
+                {
+                    ToolbarMode = { BindTarget = toolbar.ToolbarMode }
+                }
+            });
+        }
     }
 }

--- a/Jazer.Game/JazerGame.cs
+++ b/Jazer.Game/JazerGame.cs
@@ -1,8 +1,6 @@
-﻿using Jazer.Game.Graphics.Containers;
-using Jazer.Game.Overlays;
+﻿using Jazer.Game.Overlays;
 using Jazer.Game.Screens;
 using osu.Framework.Allocation;
-using osu.Framework.Graphics;
 
 namespace Jazer.Game
 {
@@ -13,16 +11,9 @@ namespace Jazer.Game
         [BackgroundDependencyLoader]
         private void load()
         {
-            Toolbar toolbar;
-
-            Add(new BorderLayout
+            Add(new ToolbarContainer
             {
-                RelativeSizeAxes = Axes.Both,
-                Top = toolbar = new Toolbar(),
-                Center = screenStack = new JazerScreenStack
-                {
-                    ToolbarMode = { BindTarget = toolbar.ToolbarMode }
-                }
+                Child = screenStack = new JazerScreenStack()
             });
         }
     }

--- a/Jazer.Game/JazerGameBase.cs
+++ b/Jazer.Game/JazerGameBase.cs
@@ -24,9 +24,13 @@ namespace Jazer.Game
 
         protected JazerGameBase()
         {
-            base.Content.Add(Content = new DrawSizePreservingFillContainer
+            base.Content.Add(new DrawSizePreservingFillContainer
             {
-                TargetDrawSize = new Vector2(1366, 768)
+                TargetDrawSize = new Vector2(1366, 768),
+                Child = Content = new GlobalActionContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                }
             });
         }
 

--- a/Jazer.Game/Overlays/JazerOverlay.cs
+++ b/Jazer.Game/Overlays/JazerOverlay.cs
@@ -1,0 +1,38 @@
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Containers;
+
+namespace Jazer.Game.Overlays;
+
+public abstract partial class JazerOverlay : Container
+{
+    public readonly BindableBool Visible;
+
+    protected JazerOverlay(bool startHidden = false)
+    {
+        Visible = new BindableBool(!startHidden);
+    }
+
+    protected abstract void PopIn();
+
+    protected abstract void PopOut();
+
+    public override void Show() => Visible.Value = true;
+
+    public override void Hide() => Visible.Value = false;
+
+    public void Toggle() => Visible.Toggle();
+
+    protected override void LoadAsyncComplete()
+    {
+        base.LoadAsyncComplete();
+
+        Visible.BindValueChanged(visible =>
+        {
+            if (visible.NewValue)
+                PopIn();
+            else
+                PopOut();
+        }, true);
+        FinishTransforms(true);
+    }
+}

--- a/Jazer.Game/Overlays/Toolbar.cs
+++ b/Jazer.Game/Overlays/Toolbar.cs
@@ -1,0 +1,51 @@
+using Jazer.Game.Graphics;
+using Jazer.Game.Screens;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+
+namespace Jazer.Game.Overlays;
+
+public partial class Toolbar : JazerOverlay
+{
+    public const float HEIGHT = 60;
+
+    protected override Container<Drawable> Content { get; }
+
+    public readonly Bindable<ToolbarMode> ToolbarMode = new Bindable<ToolbarMode>();
+
+    public Toolbar()
+    {
+        RelativeSizeAxes = Axes.X;
+        Height = HEIGHT;
+
+        InternalChild = Content = new Container
+        {
+            RelativeSizeAxes = Axes.X,
+            Height = Height,
+            Anchor = Anchor.BottomLeft,
+            Origin = Anchor.BottomLeft,
+        };
+    }
+
+    [BackgroundDependencyLoader]
+    private void load()
+    {
+        Children =
+        [
+            new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+                Colour = JazerColour.Gray700,
+            }
+        ];
+
+        ToolbarMode.BindValueChanged(mode => Visible.Value = mode.NewValue == Screens.ToolbarMode.Show, true);
+    }
+
+    protected override void PopIn() => this.ResizeHeightTo(HEIGHT, 400, Easing.OutExpo);
+
+    protected override void PopOut() => this.ResizeHeightTo(0, 400, Easing.OutExpo);
+}

--- a/Jazer.Game/Overlays/Toolbar.cs
+++ b/Jazer.Game/Overlays/Toolbar.cs
@@ -1,3 +1,5 @@
+using System;
+using Jazer.Game.Configuration;
 using Jazer.Game.Graphics;
 using Jazer.Game.Screens;
 using osu.Framework.Allocation;
@@ -5,16 +7,20 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
 
 namespace Jazer.Game.Overlays;
 
-public partial class Toolbar : JazerOverlay
+public partial class Toolbar : JazerOverlay, IKeyBindingHandler<GlobalAction>
 {
     public const float HEIGHT = 60;
 
     protected override Container<Drawable> Content { get; }
 
     public readonly Bindable<ToolbarMode> ToolbarMode = new Bindable<ToolbarMode>();
+
+    private readonly BindableBool showToolbar = new BindableBool();
 
     public Toolbar()
     {
@@ -31,8 +37,10 @@ public partial class Toolbar : JazerOverlay
     }
 
     [BackgroundDependencyLoader]
-    private void load()
+    private void load(JazerConfigManager config)
     {
+        config.BindWith(JazerSetting.ShowToolbar, showToolbar);
+
         Children =
         [
             new Box
@@ -42,10 +50,41 @@ public partial class Toolbar : JazerOverlay
             }
         ];
 
-        ToolbarMode.BindValueChanged(mode => Visible.Value = mode.NewValue == Screens.ToolbarMode.Show, true);
+        ToolbarMode.BindValueChanged(_ => toolbarModeChanged());
+        showToolbar.BindValueChanged(_ => toolbarModeChanged());
+        toolbarModeChanged();
     }
 
     protected override void PopIn() => this.ResizeHeightTo(HEIGHT, 400, Easing.OutExpo);
 
     protected override void PopOut() => this.ResizeHeightTo(0, 400, Easing.OutExpo);
+
+    private void toolbarModeChanged()
+    {
+        Visible.Value = ToolbarMode.Value switch
+        {
+            Screens.ToolbarMode.Show => true,
+            Screens.ToolbarMode.Hide => false,
+            Screens.ToolbarMode.UserTriggered => showToolbar.Value,
+            _ => throw new ArgumentOutOfRangeException()
+        };
+    }
+
+    public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+    {
+        switch (e.Action)
+        {
+            case GlobalAction.ToggleToolbar:
+                if (ToolbarMode.Value == Screens.ToolbarMode.UserTriggered)
+                    showToolbar.Toggle();
+
+                return true;
+        }
+
+        return false;
+    }
+
+    public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+    {
+    }
 }

--- a/Jazer.Game/Overlays/ToolbarContainer.cs
+++ b/Jazer.Game/Overlays/ToolbarContainer.cs
@@ -1,0 +1,36 @@
+using Jazer.Game.Graphics.Containers;
+using Jazer.Game.Screens;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+
+namespace Jazer.Game.Overlays;
+
+public partial class ToolbarContainer : Container
+{
+    protected override Container<Drawable> Content { get; }
+
+    [Cached]
+    public readonly Bindable<ToolbarMode> ToolbarMode = new Bindable<ToolbarMode>();
+
+    public readonly Toolbar Toolbar;
+
+    public ToolbarContainer()
+    {
+        RelativeSizeAxes = Axes.Both;
+
+        InternalChild = new BorderLayout
+        {
+            RelativeSizeAxes = Axes.Both,
+            Top = Toolbar = new Toolbar
+            {
+                ToolbarMode = { BindTarget = ToolbarMode }
+            },
+            Center = Content = new Container
+            {
+                RelativeSizeAxes = Axes.Both
+            }
+        };
+    }
+}

--- a/Jazer.Game/Screens/JazerScreen.cs
+++ b/Jazer.Game/Screens/JazerScreen.cs
@@ -1,0 +1,8 @@
+using osu.Framework.Screens;
+
+namespace Jazer.Game.Screens;
+
+public partial class JazerScreen : Screen
+{
+    public virtual ToolbarMode ToolbarMode => ToolbarMode.Show;
+}

--- a/Jazer.Game/Screens/JazerScreenStack.cs
+++ b/Jazer.Game/Screens/JazerScreenStack.cs
@@ -1,0 +1,20 @@
+using osu.Framework.Bindables;
+using osu.Framework.Screens;
+
+namespace Jazer.Game.Screens;
+
+public partial class JazerScreenStack : ScreenStack
+{
+    public readonly Bindable<ToolbarMode> ToolbarMode = new Bindable<ToolbarMode>();
+
+    public JazerScreenStack()
+    {
+        ScreenPushed += screenPushed;
+    }
+
+    private void screenPushed(IScreen prev, IScreen next)
+    {
+        if (next is JazerScreen jazerScreen)
+            ToolbarMode.Value = jazerScreen.ToolbarMode;
+    }
+}

--- a/Jazer.Game/Screens/JazerScreenStack.cs
+++ b/Jazer.Game/Screens/JazerScreenStack.cs
@@ -1,3 +1,4 @@
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Screens;
 
@@ -5,7 +6,8 @@ namespace Jazer.Game.Screens;
 
 public partial class JazerScreenStack : ScreenStack
 {
-    public readonly Bindable<ToolbarMode> ToolbarMode = new Bindable<ToolbarMode>();
+    [Resolved(canBeNull: true)]
+    private Bindable<ToolbarMode>? toolbarMode { get; set; } = null!;
 
     public JazerScreenStack()
     {
@@ -14,7 +16,7 @@ public partial class JazerScreenStack : ScreenStack
 
     private void screenPushed(IScreen prev, IScreen next)
     {
-        if (next is JazerScreen jazerScreen)
-            ToolbarMode.Value = jazerScreen.ToolbarMode;
+        if (toolbarMode != null && next is JazerScreen jazerScreen)
+            toolbarMode.Value = jazerScreen.ToolbarMode;
     }
 }

--- a/Jazer.Game/Screens/ToolbarMode.cs
+++ b/Jazer.Game/Screens/ToolbarMode.cs
@@ -1,0 +1,7 @@
+namespace Jazer.Game.Screens;
+
+public enum ToolbarMode
+{
+    Show,
+    Hide,
+}

--- a/Jazer.Game/Screens/ToolbarMode.cs
+++ b/Jazer.Game/Screens/ToolbarMode.cs
@@ -4,4 +4,5 @@ public enum ToolbarMode
 {
     Show,
     Hide,
+    UserTriggered,
 }


### PR DESCRIPTION
Adds a global toolbar, it's visibility is controlled through `JazerScreen.ToolbarMode`. When toolbar mode is set to `UserTriggered` it can be toggled via Ctrl+T